### PR TITLE
Bumping request minor version

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
   },
   "main": "./lib/spark",
   "dependencies": {
-    "request": ">= 2.40.0",
+    "request": ">= 2.50.0",
     "when": ">= 3.4.4"
   },
   "devDependencies": {
@@ -33,9 +33,6 @@
     "uglify-js": "2.4.x",
     "bower": ">=1.3.9",
     "jamjs": ">=0.2.17"
-  },
-  "browser": {
-    "request": "browser-request"
   },
   "jam": {
     "main": "dist/spark.min.js",


### PR DESCRIPTION
https://github.com/request/request/issues/455#issuecomment-66301197

Also, the browser-request library doesn't include the .on function used here https://github.com/spark/sparkjs/blob/master/lib/spark.js#L667, so trying to do any event subscribing in the browser just results in 'undefined is not a function' in a minified file, which isn't super helpful.