### PR TITLE
Adding other options to publishEvent

### DIFF
--- a/lib/spark-api.js
+++ b/lib/spark-api.js
@@ -501,6 +501,9 @@ SparkApi.prototype.publishEvent = function (eventName, data, accessToken, option
     data: data,
     access_token: accessToken
   };
+  if (!options) {
+    options = {};
+  }
   if (options.ttl) {
     form.ttl = options.ttl;
   }

--- a/lib/spark-api.js
+++ b/lib/spark-api.js
@@ -507,7 +507,7 @@ SparkApi.prototype.publishEvent = function (eventName, data, accessToken, option
   if (options.ttl) {
     form.ttl = options.ttl;
   }
-  if (options.private) {
+  if (typeof options.private !== 'undefined') {
     form.private = options.private;
   }
   this.request({

--- a/lib/spark-api.js
+++ b/lib/spark-api.js
@@ -489,20 +489,28 @@ SparkApi.prototype.getEventStream = function (eventName, coreId, accessToken, ca
  * @param {string} eventName - Event to register
  * @param {string} data - To be passed to the to the event
  * @param {string} accessToken - current access token
+ * @param {object} options - optionally specify values { ttl, private }
  * @param {function} callback
  * @endpoint POST /v1/devices/events
  *
  * @returns {Promise}
  */
-SparkApi.prototype.publishEvent = function (eventName, data, accessToken, callback) {
+SparkApi.prototype.publishEvent = function (eventName, data, accessToken, options, callback) {
+  var form = {
+    name: eventName,
+    data: data,
+    access_token: accessToken
+  };
+  if (options.ttl) {
+    form.ttl = options.ttl;
+  }
+  if (options.private) {
+    form.private = options.private;
+  }
   this.request({
     uri: this.baseUrl + '/v1/devices/events',
     method: 'POST',
-    form: {
-      name: eventName,
-      data: data,
-      access_token: accessToken
-    },
+    form: form,
     json: true
   }, callback);
 };

--- a/lib/spark.js
+++ b/lib/spark.js
@@ -703,16 +703,17 @@ Spark.prototype.onEvent = function(eventName, callback) {
  *
  * @param {string} eventName - Event to register
  * @param {string} data - To be passed to the to the event
+ * @param {object} options - optionally specify values { ttl, private }
  * @param {function} callback
  * @endpoint POST /v1/devices/events
  *
  * @returns {Promise}
  */
-Spark.prototype.publishEvent = function (eventName, data, callback) {
+Spark.prototype.publishEvent = function (eventName, data, options, callback) {
   var defer = this.createDefer('publishEvent', callback),
       handler = this.defaultHandler('publishEvent', defer, callback).bind(this);
 
-  this.api.publishEvent(eventName, data, this.accessToken, handler);
+  this.api.publishEvent(eventName, data, this.accessToken, options, handler);
 
   var promise = (!!defer) ? defer.promise : null;
   return promise;

--- a/test/specs/spark-api-spec.js
+++ b/test/specs/spark-api-spec.js
@@ -311,7 +311,7 @@ describe('SparkApi', function() {
 
   describe('publishEvent', function() {
     var subject = function(api, callback) {
-      return api.publishEvent('event_name', 'data', 'token', callback);
+      return api.publishEvent('event_name', 'data', 'token', null, callback);
     };
     var args = {
       uri: 'https://api.spark.io/v1/devices/events',
@@ -320,6 +320,26 @@ describe('SparkApi', function() {
         name: 'event_name',
         data: 'data',
         access_token: 'token'
+      },
+      json: true
+    };
+
+    shared.behavesLikeEndpoint(subject, args);
+  });
+
+  describe('publishEvent with optional argument', function() {
+    var subject = function(api, callback) {
+      return api.publishEvent('event_name', 'data', 'token', {private: false, ttl:123}, callback);
+    };
+    var args = {
+      uri: 'https://api.spark.io/v1/devices/events',
+      method: 'POST',
+      form: {
+        name: 'event_name',
+        data: 'data',
+        access_token: 'token',
+        private: false,
+        ttl: 123
       },
       json: true
     };

--- a/test/specs/spark-spec.js
+++ b/test/specs/spark-spec.js
@@ -268,7 +268,7 @@ describe('Spark', function() {
   describe('publishEvent', function() {
     var subject = function(callback) {
       Spark.accessToken = 'token';
-      return Spark.publishEvent('event_name', 'data', callback);
+      return Spark.publishEvent('event_name', 'data', null, callback);
     };
     var data = {
       ok: true,


### PR DESCRIPTION
The publishEvent API endpoint supports more options, including ttl and private. This PR exposes those options to callers. Unfortunately, it is a breaking change for anyone who specified a callback, but since it's marked as limited beta, hopefully that's okay.
