### PR TITLE
Just check for presence of data.id

### DIFF
--- a/lib/spark.js
+++ b/lib/spark.js
@@ -203,7 +203,7 @@ Spark.prototype.getDevice = function (deviceId, callback) {
 
   var handler = function(err, response, data) {
     err = this.normalizeErr(err, data);
-    if (data && (data.id == deviceId)) {
+    if (data && data.id ) {
       device = new Device(data, this);
     }
     this.resolveDefer(defer, err, device);


### PR DESCRIPTION
As [discussed on the forums](https://community.spark.io/t/unclear-that-api-can-take-take-device-name-instead-of-device-id/11560),
the API accepts either the ID or the device name as `DEVICE_NAME` when
calling `api.spark.io/v1/devices/{DEVICE_NAME}`. The check that was in
place disables the ability to use the name instead of the ID though.
Just checking for the presence of `data.id` should be enough to verify
that a valid device was returned.