### PR TITLE
Remove private beta notification for `publishEvent`

### DIFF
--- a/examples/node/publish-event.js
+++ b/examples/node/publish-event.js
@@ -4,7 +4,6 @@
 var spark = require('spark');
 
 spark.on('login', function() {
-  //This feature is in a limited beta, and is not yet generally available
   var publishEventPr = spark.publishEvent('test', {});
 
   publishEventPr.then(


### PR DESCRIPTION
publishing events from particle-cli and sparkjs is no longer limited to private beta participants.