### PR TITLE
Changed module export

### DIFF
--- a/lib/spark.js
+++ b/lib/spark.js
@@ -178,20 +178,21 @@ Spark.prototype.include = function(plugins) {
  * @endpoint GET /oauth/token
  */
 Spark.prototype.login = function (params, callback) {
-  var defer = this.createDefer('login', callback);
+  var client = new Spark(params);
+  var defer = client.createDefer('login', callback);
 
-  var handler = this.defaultHandler('login', defer, callback, function(data) {
-    this.accessToken = data.access_token || data.accessToken;
-  }.bind(this));
+  var handler = client.defaultHandler('login', defer, callback, function(data) {
+    client.accessToken = data.access_token || data.accessToken;
+  }.bind(client));
 
   if (params.accessToken) {
     handler(null, params, params);
   } else {
-    this.api.login(params, handler);
+    client.api.login(params, handler);
   }
 
   var promise = (!!defer) ? defer.promise : null;
-  return promise;
+  return client;
 };
 
 /**
@@ -838,4 +839,4 @@ Spark.prototype.listWebhooks = function (callback) {
   return promise;
 };
 
-module.exports = Spark;
+module.exports = new Spark();

--- a/lib/spark.js
+++ b/lib/spark.js
@@ -838,4 +838,4 @@ Spark.prototype.listWebhooks = function (callback) {
   return promise;
 };
 
-module.exports = new Spark();
+module.exports = Spark;


### PR DESCRIPTION
Instead of exporting a constructed library, export the constructor. This way multiple instances can be obtained so to permit multiple integrations/interactions.
I know this is a breaking change, but it permits much better integrations, like with Telegram bots.
